### PR TITLE
Update swagger-codegen-cli

### DIFF
--- a/bin/swagger-codegen-cli.js
+++ b/bin/swagger-codegen-cli.js
@@ -1,5 +1,8 @@
-#!/usr/bin/env node
+//This version of the swagger-nodegen-cli launches a customized version of the swagger-codegen-cli-2.4.5.jar
+//This custom jar was built using the source for swagger-codegen-cli-2.4.5 with the addition of the following PR
+//https://github.com/swagger-api/swagger-codegen/pull/8845
+#!/usr/bin / env node
 require('child_process')
   .spawn('java', [
-    '-jar', __dirname + '/swagger-codegen-cli-2.4.4.jar']
+    '-jar', __dirname + '/swagger-codegen-cli-2.4.5-mitel.1.jar']
       .concat(process.argv.slice(2)), {stdio: 'inherit'})

--- a/bin/swagger-codegen-cli.js
+++ b/bin/swagger-codegen-cli.js
@@ -1,8 +1,9 @@
-//This version of the swagger-nodegen-cli launches a customized version of the swagger-codegen-cli-2.4.5.jar
-//This custom jar was built using the source for swagger-codegen-cli-2.4.5 with the addition of the following PR
-//https://github.com/swagger-api/swagger-codegen/pull/8845
-#!/usr/bin / env node
+#!/usr/bin/env node
 require('child_process')
   .spawn('java', [
     '-jar', __dirname + '/swagger-codegen-cli-2.4.5-mitel.1.jar']
       .concat(process.argv.slice(2)), {stdio: 'inherit'})
+      
+//This version of the swagger-nodegen-cli launches a customized version of the swagger-codegen-cli-2.4.5.jar
+//This custom jar was built using the source for swagger-codegen-cli-2.4.5 with the addition of the following PR
+//https://github.com/swagger-api/swagger-codegen/pull/8845

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "swagger-nodegen-cli",
-  "version": "2.4.4",
-  "description": "A simple convenience package that wraps the swagger-codegen-cli-2.4.4 for the node/npm environment.",
+  "version": "2.4.5-mitel.1",
+  "description": "A simple convenience package that wraps the swagger-codegen-cli-2.4.5-mitel.1 for the node/npm environment.",
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/sius/swagger-nodegen-cli.git"
+    "url": "https://github.com/mitel-networks/swagger-nodegen-cli.git"
   },
   "scripts": {
     "test": "echo \"no tests specified, but that's Ok!\" && exit 0"
@@ -14,6 +14,6 @@
     "swagger-codegen-cli": "bin/swagger-codegen-cli.js",
     "swagger-nodegen-cli": "bin/swagger-codegen-cli.js"
   },
-  "author": "sius",
+  "author": "Brett McGillis",
   "license": "Apache-2.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
-  "name": "swagger-nodegen-cli",
+  "name": "@mitel/swagger-nodegen-cli",
   "version": "2.4.5-mitel.1",
-  "description": "A simple convenience package that wraps the swagger-codegen-cli-2.4.5-mitel.1 for the node/npm environment.",
+  "description": "A simple convenience package that wraps the swagger-codegen-cli for the node/npm environment.",
   "main": "index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/mitel-networks/swagger-nodegen-cli.git"
+  },
+  "publishConfig": {
+    "registry": "https://depot.mitel.io/artifactory/api/npm/mitel/"
   },
   "scripts": {
     "test": "echo \"no tests specified, but that's Ok!\" && exit 0"
@@ -14,6 +17,6 @@
     "swagger-codegen-cli": "bin/swagger-codegen-cli.js",
     "swagger-nodegen-cli": "bin/swagger-codegen-cli.js"
   },
-  "author": "Brett McGillis",
+  "author": "sius",
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
- Built swagger-codegen-cli-2.4.5 with the inclusion of https://github.com/swagger-api/swagger-codegen/pull/8845
- Updated swagger-codegen-cli.js to call new jar file, and included comments on how the jar was built.
- Updated version, url and author in package.json
